### PR TITLE
new generators page with all apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "bootstrap": "^3.4.1",
         "openai": "^2.0.5",
         "react": "^18.0.0",
-        "react-bootstrap": "^2.2.3",
+        "react-bootstrap": "^2.4.0",
         "react-bootstrap-validation": "^0.1.11",
         "react-dom": "^18.0.0",
         "react-router": "^6.3.0",
@@ -2095,11 +2095,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
       "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="
-    },
-    "node_modules/@types/invariant": {
-      "version": "2.2.35",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.35.tgz",
-      "integrity": "sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg=="
     },
     "node_modules/@types/jest": {
       "version": "27.4.1",
@@ -16154,18 +16149,14 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.2.3.tgz",
-      "integrity": "sha512-gXsAEBdDUHnOpJ2C+DDQ4mFt7tN6u6qWnTH3tqiE9jUvV6gGY8uHFp0iGBsM+yjrBwmR6bqCBFh8Z82aQj1LSw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.4.0.tgz",
+      "integrity": "sha512-dn599jNK1Fg5GGjJH+lQQDwELVzigh/MdusKpB/0el+sCjsO5MZDH5gRMmBjRhC+vb7VlCDr6OXffPIDSkNMLw==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "@restart/hooks": "^0.4.6",
         "@restart/ui": "^1.2.0",
-        "@types/invariant": "^2.2.35",
-        "@types/prop-types": "^15.7.4",
-        "@types/react": ">=16.14.8",
         "@types/react-transition-group": "^4.4.4",
-        "@types/warning": "^3.0.0",
         "classnames": "^2.3.1",
         "dom-helpers": "^5.2.1",
         "invariant": "^2.2.4",
@@ -16176,8 +16167,14 @@
         "warning": "^4.0.3"
       },
       "peerDependencies": {
+        "@types/react": ">=16.14.8",
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-bootstrap-validation": {
@@ -22093,11 +22090,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
       "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="
-    },
-    "@types/invariant": {
-      "version": "2.2.35",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.35.tgz",
-      "integrity": "sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg=="
     },
     "@types/jest": {
       "version": "27.4.1",
@@ -33289,18 +33281,14 @@
       }
     },
     "react-bootstrap": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.2.3.tgz",
-      "integrity": "sha512-gXsAEBdDUHnOpJ2C+DDQ4mFt7tN6u6qWnTH3tqiE9jUvV6gGY8uHFp0iGBsM+yjrBwmR6bqCBFh8Z82aQj1LSw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.4.0.tgz",
+      "integrity": "sha512-dn599jNK1Fg5GGjJH+lQQDwELVzigh/MdusKpB/0el+sCjsO5MZDH5gRMmBjRhC+vb7VlCDr6OXffPIDSkNMLw==",
       "requires": {
         "@babel/runtime": "^7.17.2",
         "@restart/hooks": "^0.4.6",
         "@restart/ui": "^1.2.0",
-        "@types/invariant": "^2.2.35",
-        "@types/prop-types": "^15.7.4",
-        "@types/react": ">=16.14.8",
         "@types/react-transition-group": "^4.4.4",
-        "@types/warning": "^3.0.0",
         "classnames": "^2.3.1",
         "dom-helpers": "^5.2.1",
         "invariant": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap": "^3.4.1",
     "openai": "^2.0.5",
     "react": "^18.0.0",
-    "react-bootstrap": "^2.2.3",
+    "react-bootstrap": "^2.4.0",
     "react-bootstrap-validation": "^0.1.11",
     "react-dom": "^18.0.0",
     "react-router": "^6.3.0",

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
   integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS"
   crossorigin="anonymous"/>
   
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/ash-logo.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,7 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "ash-logo.png",
       "type": "image/png",
       "sizes": "192x192"
     },

--- a/src/App.css
+++ b/src/App.css
@@ -13,6 +13,7 @@ body {
 }
 h1{
   font-size: 2.3rem;
+  text-align: center; 
 }
 h2{
 	font-size: 1.37rem;
@@ -91,4 +92,12 @@ textarea{
 img.logo{
   max-width: 204px;
   border-radius: 9999px;
+}
+/* generators page */
+#generators{
+  padding-top: 5%;
+  padding-bottom: 5%;
+}
+#generators h1{
+  padding-bottom: 5%;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import ProductDescription from './components/ProductDescription';
 import BlogIntro from './components/BlogIntro';
 import CompanyBio from './components/CompanyBio';
 import LinkedInJobDescription from './components/LinkedInJobDescription';
-
+import Generators from './components/Generators';
 
 
 function App() {
@@ -25,6 +25,7 @@ function App() {
         <Route path="/blog-intro" element={<BlogIntro/>} />
         <Route path="/company-bio" element={<CompanyBio/>} />
         <Route path="/li-job-description" element={<LinkedInJobDescription/>} />
+        <Route path="/generators" element={<Generators/>} />
       </Routes>
 
       </div>

--- a/src/components/Generators.js
+++ b/src/components/Generators.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Component } from 'react'
+import { Container, Card, Row, Col, Button } from 'react-bootstrap'
+
+class Generators extends Component {
+render() {
+    return (
+        <Container>
+        <Row>
+        <Col sm={6}>
+        <Card className="text-center">
+            <Card.Header><h2>Product Description</h2></Card.Header>
+            <Card.Body>
+                <Card.Text>
+                <p>Generate an awesome Product Description</p>
+                <Button href="product-description">Product Description Generator</Button>
+                </Card.Text>
+            </Card.Body>
+        </Card>
+        </Col>
+        <Col sm={6}>
+        <Card className="text-center">
+            <Card.Header><h2>Company Bio</h2></Card.Header>
+            <Card.Body>
+                <Card.Text>
+                <p>Generate an awesome Company Bio</p>
+                <Button href="company-bio">Company Bio Generator</Button>
+                </Card.Text>
+            </Card.Body>
+        </Card>
+        </Col>
+        <Col sm={6}>
+        <Card className="text-center">
+            <Card.Header><h2>Blog Intro</h2></Card.Header>
+            <Card.Body>
+                <Card.Text>
+                <p>Generate an awesome Blog Into Paragraph</p>
+                <Button href="blog-intro">Blog Intro Generator</Button>
+                </Card.Text>
+            </Card.Body>
+        </Card>
+        </Col>
+        <Col sm={6}>
+        <Card className="text-center">
+            <Card.Header><h2>LinkedIn Job Description</h2></Card.Header>
+            <Card.Body>
+                <Card.Text>
+                 <p>Generate a knowledgeable LinkedIn Job Description</p>
+                <Button href="li-job-description">Job Description Generator</Button>
+                </Card.Text>
+            </Card.Body>
+        </Card>
+        </Col>
+    </Row>
+    </Container>
+    )    
+}
+}
+export default Generators;

--- a/src/components/Generators.js
+++ b/src/components/Generators.js
@@ -2,9 +2,12 @@ import React from 'react'
 import { Component } from 'react'
 import { Container, Card, Row, Col, Button } from 'react-bootstrap'
 
+
 class Generators extends Component {
 render() {
     return (
+        <div id="generators">               
+        <h1>Content Generators</h1>
         <Container>
         <Row>
         <Col sm={6}>
@@ -53,6 +56,7 @@ render() {
         </Col>
     </Row>
     </Container>
+    </div> 
     )    
 }
 }

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -18,6 +18,7 @@ class Navigation extends Component {
                         <Nav.Link href="company-bio">Company Bio</Nav.Link>
                         <Nav.Link href="blog-intro">Blog Intro</Nav.Link>
                         <Nav.Link href="li-job-description">LinkedIn Job Description</Nav.Link>
+                        <Nav.Link href="generators">Generators</Nav.Link>
                     </Nav>
                     </Navbar.Collapse>
                 </Container>


### PR DESCRIPTION
The navigation is getting cluttered, so this Generators page was created to add more content generators and have them easily accessible on their page instead of the navigation bar in a dropdown. 

The full change: 

- a new page with the slug /generators. 
- all the ai content generators are displayed on that page with cards
- a link has been added to the navigation
- router has been added to app.js
- adds simple styles padding to top and bottom of page and to title