### PR TITLE
Bug fix: Format Brainstorm response should as list

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -101,3 +101,7 @@ img.logo{
 #generators h1{
   padding-bottom: 5%;
 }
+
+.pre-wrap{
+  white-space: pre-wrap;
+}

--- a/src/components/Brainstorm.js
+++ b/src/components/Brainstorm.js
@@ -43,7 +43,7 @@ class Brainstorm extends Component {
             })
         }); 
     }
-
+  
     render () {
         return (
         <div id="main-content">
@@ -52,6 +52,7 @@ class Brainstorm extends Component {
         <Col xs={6} md={4}>
         <h1>Brainstorm Ideas</h1>
         <p id="pageDescription">Enter your your content type and topic and get a list of ideas generated for you by AI. </p>
+        
 
         <Form onSubmit={this.onFormSubmit}>
         <Form.Group className="mb-3" controlId="textArea">
@@ -72,7 +73,7 @@ class Brainstorm extends Component {
         <Card.Body>
             <Card.Title></Card.Title>
             <Card.Text>
-            <p>{this.state.response}</p>
+            <p className="pre-wrap">{this.state.response}</p>
             </Card.Text>
         </Card.Body>
         </Card>


### PR DESCRIPTION
This fixes Brainstorm Generator response should display as list #13.

Added the following CSS class to the response state in the generator: 

```
.pre-wrap{
  white-space: pre-wrap;
}
```

Before: 
<img width="641" alt="Screen Shot 2022-08-21 at 9 39 30 AM" src="https://user-images.githubusercontent.com/29527450/185799014-bcaee5bd-56f7-48a6-a2cd-369efc42ff88.png">

After: 
<img width="658" alt="Screen Shot 2022-08-21 at 9 39 04 AM" src="https://user-images.githubusercontent.com/29527450/185799004-d7c3de99-ad43-409e-9e65-04cd40a97f84.png">
 