### PR TITLE
GeneratorComponent: Update AI Response Card Header Title's Grammar

### DIFF
--- a/src/components/GeneratorCoponent.js
+++ b/src/components/GeneratorCoponent.js
@@ -28,7 +28,7 @@ const GeneratorComponent = (props) => {
       if (data.error) {
         setErrorMessage(data.message);
       } else {
-        setHeading(`Here's your ${props.generatorData.title}:`);
+        setHeading(`Your AI Generated ${props.generatorData.title}:`);
         setResponse(data);
       }
       setDataLoaded(true);


### PR DESCRIPTION
This PR addresses the issue [Update Card Header Title to be Grammatically Correct and More Informative](https://github.com/ash1eygrace/ai-content/issues/50) #50 

The current header title, "Here's your response," may not always be grammatically correct and lacks context in different Generator scenarios.

Changes:

 - Updated the card header title in GeneratorComponent to display a more descriptive and informative title based on the AI-generated content.
- Ensured that the new header title is grammatically correct and provides informative context in various scenarios.

Testing:

- Navigate to Generators > and open some to test. 
- Submit a query to generate a response. 
- Wait for the Generated response and the title should say Your AI Generated {title of the generator}. 

Before it would say:

`Here's your ${props.generatorData.title}:` e.g. Here's your Blog Post Ideas / Here's Your TL;DR

After:

`Your AI Generated ${props.generatorData.title}:` e.g. Your AI Generated Blog Post Ideas / Your AI Generated Tl;DR
