### PR TITLE
Theme: Add dark theme with toggle for light theme 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "copyai",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.4.0",
         "bootstrap": "^3.4.1",
         "openai": "^2.0.5",
         "react": "^18.0.0",
@@ -1807,6 +1808,15 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.0.tgz",
+      "integrity": "sha512-0NyytTlPJwB/BF5LtRV8rrABDbe3TdTXqNB3PdZ+UUUZAEIrdOJdmABqKjt4AXwIoJNaRVVZEXxpNrqvE1GAYQ==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -21493,6 +21503,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
+    },
+    "@fortawesome/fontawesome-free": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.0.tgz",
+      "integrity": "sha512-0NyytTlPJwB/BF5LtRV8rrABDbe3TdTXqNB3PdZ+UUUZAEIrdOJdmABqKjt4AXwIoJNaRVVZEXxpNrqvE1GAYQ=="
     },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.4.0",
     "bootstrap": "^3.4.1",
     "openai": "^2.0.5",
     "react": "^18.0.0",

--- a/src/App.css
+++ b/src/App.css
@@ -14,8 +14,6 @@
   --dark-btn-hover-color: #dc7684;
 }
 
-
-
 .dark-mode {
   --primary-color: var(--dark-primary-color);
   --secondary-color: var(--dark-secondary-color);
@@ -65,7 +63,6 @@ p {
 }
 /*Home Page*/
 #hero {
-  padding-top: 5%;
   padding-bottom: 3%;
   text-align: center;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,114 +1,146 @@
+:root {
+  --primary-color: #8484c3;
+  --secondary-color: #5cb0a2;
+  --text-color: #242325;
+  --background-color: #F8F7F9;
+  --btn-hover-color: #dc7684;
+  --white-color: #F8F7F9;
+
+  /* Dark mode variables */
+  --dark-primary-color: #1E2028;
+  --dark-secondary-color: #5cb0a2;
+  --dark-text-color: #b3b6bd;
+  --dark-background-color: #2A2D34;
+  --dark-btn-hover-color: #dc7684;
+}
+
+
+
+.dark-mode {
+  --primary-color: var(--dark-primary-color);
+  --secondary-color: var(--dark-secondary-color);
+  --text-color: var(--dark-text-color);
+  --background-color: var(--dark-background-color);
+  --btn-hover-color: var(--dark-btn-hover-color);
+}
+
 @media (max-width: 768px) {
-  .col-6{
+  .col-6 {
     flex: 0 0 100%;
     max-width: 100%;
   }
-  .btn-primary{
+  .btn-primary {
     margin-bottom: 10%;
   }
 }
 body {
-	background: #F8F7F9;
-	font-family: 'Open Sans', sans-serif;
+  background: var(--background-color);
+  font-family: 'Open Sans', sans-serif;
 }
-h1{
+h1 {
   font-size: 2.3rem;
-  text-align: center; 
-  padding-bottom:5%;
+  text-align: center;
+  padding-bottom: 5%;
 }
-h2{
-	font-size: 1.37rem;
+h2 {
+  font-size: 1.37rem;
 }
-p{
-	font-size: 1.2rem;
+p {
+  font-size: 1.2rem;
 }
-#main{
-  margin-top: 6%;
-  color: #242325;
+#main {
+  background-color: var(--background-color);
+  padding: 6%;
+  height: 100vh;
+  color: var(--text-color);
 }
 /* Nav*/
-#navigation{
-  background-color: #8484c3;
+#navigation {
+  background-color: var(--primary-color);
   padding: 1%;
 }
-.navbar-light .navbar-nav .nav-link, .navbar-nav a.navbar-brand{
-  color: #F8F7F9;
+.navbar-light .navbar-nav .nav-link,
+.navbar-nav a.navbar-brand {
+  color: var(--white-color);
 }
 /*Home Page*/
-#hero{
+#hero {
   padding-top: 5%;
   padding-bottom: 3%;
-  text-align: center; 
+  text-align: center;
 }
-#hero h1{
+#hero h1 {
   padding-top: 2%;
   padding-bottom: 2%;
 }
-#hero p{
+#hero p {
   padding-left: 14%;
   padding-right: 14%;
   padding-bottom: 8%;
 }
-img.logo{
+img.logo {
   max-width: 204px;
   border-radius: 9999px;
 }
 /*Generator*/
-#pageDescription{
+#pageDescription {
   padding-bottom: 10%;
 }
-textarea{
+textarea {
   resize: none;
 }
-label.form-label{
+label.form-label {
   font-weight: bold;
-} 
-.pre-wrap{
+}
+.pre-wrap {
   white-space: pre-wrap;
 }
 .copy-button {
   color: #fff;
-  background-color: #5cb0a2;
+  background-color: var(--secondary-color);
   position: absolute;
   bottom: 10px;
   right: 10px;
 }
 .response-container {
-  margin-bottom: 60px;;
+  margin-bottom: 60px;
 }
 /* Buttons */
-.btn:hover{
-  box-shadow: 1px 1px 2px rgba(74, 48, 89, .4);
+.btn:hover {
+  box-shadow: 1px 1px 2px rgba(74, 48, 89, 0.4);
   cursor: pointer;
-	color: #F8F7F9;
-	background-color: #dc7684;
+  color: var(--white-color);
+  background-color: var(--btn-hover-color);
 }
-.btn-primary{
+.btn-primary {
   padding-top: 4%;
   padding-bottom: 4%;
-  background-color: #5cb0a2;
+  background-color: var(--secondary-color);
   border: none;
   float: right;
   min-width: 100%;
 }
 /*Cards*/
-.card-header{
+.card-header {
   padding-top: 4%;
   padding-bottom: 4%;
-  background-color: #8484c3;
-  color: #F8F7F9;
+  background-color: var(--primary-color);
+  color: var(--white-color);
 }
-.card{
-  background-color: white;
+.card {
+  background-color: var(--background-color);
   box-shadow: 1px 1px 5px rgba(0, 0, 0, .22);
   min-height: 79vh;
   min-height: 100%;
   border-radius: 0.25rem;
 }
-.col-sm-6{
+.card-body {
+  background-color: var(--background-color);
+}
+.col-sm-6 {
   margin-bottom: 20px;
 }
-.col-sm-6 .card p{
+.col-sm-6 .card p {
   margin-top: 35px;
   margin-bottom: 45px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -93,9 +93,12 @@ label.form-label {
   white-space: pre-wrap;
 }
 .copy-button {
-  color: #fff;
+  color: var(--white-color);
   background-color: var(--secondary-color);
+  border: none;
   position: absolute;
+  width: 40px;
+  height: 40px;
   bottom: 10px;
   right: 10px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -141,3 +141,22 @@ label.form-label {
   margin-top: 35px;
   margin-bottom: 45px;
 }
+
+.theme-toggle {
+  background-color: var(--background-color);
+  width: 40px;
+  height: 40px;
+  border: none;
+  font-size: 24px;
+  padding: 10x 10px;
+  color: var(--text-color);
+  border-radius: 5px;
+  transition: color 0.2s;
+}
+button:focus {
+  outline: none;
+}
+
+.theme-toggle .fas.fa-sun {
+  color: #F4D35E;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import './App.css';
 import 'react-bootstrap/dist/react-bootstrap.min.js';
-import React, { useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
 import Navigation from './components/common/Navigation';
@@ -9,28 +9,39 @@ import Generators from './components/generators/Generators';
 import GeneratorComponent from './components/generators/Generator';
 
 import { generatorList } from './data/generatorList';
-import ThemeContext from './components/common/ThemeContext';
+import { ThemeContext } from './components/common/ThemeContext';
+import ThemeToggle from './components/common/ThemeToggle';
 
 function App() {
-  const { isDarkMode } = useContext(ThemeContext);
+  const [isDarkMode, setIsDarkMode] = useState(() => {
+    const storedTheme = localStorage.getItem('theme');
+    return storedTheme !== null ? JSON.parse(storedTheme) : true;
+  });
+  const toggleTheme = () => setIsDarkMode(!isDarkMode);
+
+  useEffect(() => {
+    localStorage.setItem('theme', JSON.stringify(isDarkMode));
+  }, [isDarkMode]);
 
   return (
-    <Router>
-      <div className={`App${isDarkMode ? ' dark-mode' : ''}`}>
-        <Navigation />
-        <Routes>
-          <Route path="/" exact element={<Home />} />
-          <Route path="/generators" element={<Generators />} />
-          {generatorList.map((generator) => (
-            <Route
-              key={generator.id}
-              path={`/${generator.link}`}
-              element={<GeneratorComponent generatorData={generator} />}
-            />
-          ))}
-        </Routes>
-      </div>
-    </Router>
+    <ThemeContext.Provider value={{ isDarkMode, toggleTheme }}>
+      <Router>
+        <div className={`App ${isDarkMode ? 'dark-mode' : 'light-mode'}`}>
+          <Navigation />
+          <Routes>
+            <Route path="/" exact element={<Home />} />
+            <Route path="/generators" element={<Generators />} />
+            {generatorList.map((generator) => (
+              <Route
+                key={generator.id}
+                path={`/${generator.link}`}
+                element={<GeneratorComponent generatorData={generator} />}
+              />
+            ))}
+          </Routes>
+        </div>
+      </Router>
+    </ThemeContext.Provider>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,6 @@ import GeneratorComponent from './components/generators/Generator';
 
 import { generatorList } from './data/generatorList';
 import { ThemeContext } from './components/common/ThemeContext';
-import ThemeToggle from './components/common/ThemeToggle';
 
 function App() {
   const [isDarkMode, setIsDarkMode] = useState(() => {

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import './App.css';
 import 'react-bootstrap/dist/react-bootstrap.min.js';
-import React from 'react';
+import React, { useContext } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
 import Navigation from './components/common/Navigation';
@@ -9,11 +9,14 @@ import Generators from './components/generators/Generators';
 import GeneratorComponent from './components/generators/Generator';
 
 import { generatorList } from './data/generatorList';
+import ThemeContext from './components/common/ThemeContext';
 
 function App() {
+  const { isDarkMode } = useContext(ThemeContext);
+
   return (
     <Router>
-      <div className="App">
+      <div className={`App${isDarkMode ? ' dark-mode' : ''}`}>
         <Navigation />
         <Routes>
           <Route path="/" exact element={<Home />} />

--- a/src/components/common/Navigation.js
+++ b/src/components/common/Navigation.js
@@ -1,23 +1,35 @@
 import { Nav, Navbar, Container } from 'react-bootstrap';
-import React from 'react';
+import React, { useContext } from 'react';
+import ThemeContext from  '../common/ThemeContext';
 
-const Navigation = React.memo(() => (
+const Navigation = React.memo(() => {
+  const { isDarkMode, setIsDarkMode } = useContext(ThemeContext);
+
+  const handleThemeToggle = () => {
+    setIsDarkMode(!isDarkMode);
+  };
+
+  return (
     <div id="navigation">
-        <Navbar expand="md">
-            <Container>
-                <Nav>
-                    <Navbar.Brand href="/">AshAI</Navbar.Brand>
-                </Nav>
-                <Navbar.Toggle />
-                <Navbar.Collapse>
-                    <Nav className="ml-auto">
-                        <Nav.Link href="/">Home</Nav.Link>
-                        <Nav.Link href="generators">Generators</Nav.Link>
-                    </Nav>
-                </Navbar.Collapse>
-            </Container>
-        </Navbar>
+      <Navbar expand="md">
+        <Container>
+          <Nav>
+            <Navbar.Brand href="/">AshAI</Navbar.Brand>
+          </Nav>
+          <Navbar.Toggle />
+          <Navbar.Collapse>
+            <Nav className="ml-auto">
+              <Nav.Link href="/">Home</Nav.Link>
+              <Nav.Link href="generators">Generators</Nav.Link>
+              <Nav.Link onClick={handleThemeToggle}>
+                {isDarkMode ? 'Light Mode' : 'Dark Mode'}
+              </Nav.Link>
+            </Nav>
+          </Navbar.Collapse>
+        </Container>
+      </Navbar>
     </div>
-));
+  );
+});
 
 export default Navigation;

--- a/src/components/common/Navigation.js
+++ b/src/components/common/Navigation.js
@@ -1,35 +1,25 @@
 import { Nav, Navbar, Container } from 'react-bootstrap';
-import React, { useContext } from 'react';
-import ThemeContext from  '../common/ThemeContext';
+import React from 'react';
+import ThemeToggle from './ThemeToggle';
 
-const Navigation = React.memo(() => {
-  const { isDarkMode, setIsDarkMode } = useContext(ThemeContext);
-
-  const handleThemeToggle = () => {
-    setIsDarkMode(!isDarkMode);
-  };
-
-  return (
-    <div id="navigation">
-      <Navbar expand="md">
-        <Container>
-          <Nav>
-            <Navbar.Brand href="/">AshAI</Navbar.Brand>
+const Navigation = React.memo(() => (
+  <div id="navigation">
+    <Navbar expand="md">
+      <Container>
+        <Nav>
+          <Navbar.Brand href="/">AshAI</Navbar.Brand>
+        </Nav>
+        <Navbar.Toggle />
+        <Navbar.Collapse>
+          <Nav className="ml-auto">
+            <Nav.Link href="/">Home</Nav.Link>
+            <Nav.Link href="generators">Generators</Nav.Link>
+            <ThemeToggle /> {/* Add the ThemeToggle component here */}
           </Nav>
-          <Navbar.Toggle />
-          <Navbar.Collapse>
-            <Nav className="ml-auto">
-              <Nav.Link href="/">Home</Nav.Link>
-              <Nav.Link href="generators">Generators</Nav.Link>
-              <Nav.Link onClick={handleThemeToggle}>
-                {isDarkMode ? 'Light Mode' : 'Dark Mode'}
-              </Nav.Link>
-            </Nav>
-          </Navbar.Collapse>
-        </Container>
-      </Navbar>
-    </div>
-  );
-});
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  </div>
+));
 
 export default Navigation;

--- a/src/components/common/ThemeContext.js
+++ b/src/components/common/ThemeContext.js
@@ -1,15 +1,14 @@
 import React, { createContext, useState } from 'react';
 
-const ThemeContext = createContext();
+export const ThemeContext = createContext();
 
 export const ThemeProvider = ({ children }) => {
-  const [isDarkMode, setIsDarkMode] = useState(true);
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  const toggleTheme = () => setIsDarkMode(!isDarkMode);
 
   return (
-    <ThemeContext.Provider value={{ isDarkMode, setIsDarkMode }}>
+    <ThemeContext.Provider value={{ isDarkMode, toggleTheme }}>
       {children}
     </ThemeContext.Provider>
   );
 };
-
-export default ThemeContext;

--- a/src/components/common/ThemeContext.js
+++ b/src/components/common/ThemeContext.js
@@ -1,0 +1,15 @@
+import React, { createContext, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [isDarkMode, setIsDarkMode] = useState(true);
+
+  return (
+    <ThemeContext.Provider value={{ isDarkMode, setIsDarkMode }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeContext;

--- a/src/components/common/ThemeToggle.js
+++ b/src/components/common/ThemeToggle.js
@@ -1,0 +1,14 @@
+import React, { useContext } from 'react';
+import { ThemeContext } from './ThemeContext';
+
+const ThemeToggle = () => {
+  const { isDarkMode, toggleTheme } = useContext(ThemeContext);
+
+  return (
+    <button onClick={toggleTheme}>
+      {isDarkMode ? 'Switch to Day Mode' : 'Switch to Night Mode'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/common/ThemeToggle.js
+++ b/src/components/common/ThemeToggle.js
@@ -5,8 +5,12 @@ const ThemeToggle = () => {
   const { isDarkMode, toggleTheme } = useContext(ThemeContext);
 
   return (
-    <button onClick={toggleTheme}>
-      {isDarkMode ? 'Switch to Day Mode' : 'Switch to Night Mode'}
+    <button onClick={toggleTheme} className="theme-toggle">
+      {isDarkMode ? (
+        <i className="fas fa-sun"></i>
+      ) : (
+        <i className="fas fa-moon"></i>
+      )}
     </button>
   );
 };

--- a/src/components/generators/GeneratorCard.js
+++ b/src/components/generators/GeneratorCard.js
@@ -10,8 +10,8 @@ const GeneratorCard = ({ generator }) => (
             <Card.Body>
                 <Card.Text>
                     {generator.description}
-                    <Button href={generator.link}>{generator.title}</Button>
                 </Card.Text>
+                <Button href={generator.link}>{generator.title}</Button>
             </Card.Body>
         </Card>
     </Col>

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import { ThemeProvider } from './components/common/ThemeContext';
+import '@fortawesome/fontawesome-free/css/all.css';
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
+import { ThemeProvider } from './components/common/ThemeContext';
 
 ReactDOM.render(
-   
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
This solves [Feature Request: Add Light and Dark Mode Theme Support](https://github.com/ash1eygrace/ai-content/issues/47) #47 

Changes: 

- updates to CSS, including a new dark mode theme
- adds a dark theme with a toggle button to switch to a light theme, and we preserve the state of the theme choice in local storage 
- The toggle button displays a sun for the light theme and a moon for the dark theme from font awesome. 
- fixed the overflow issue with the button in the generator cards by moving it out of card text.

![ai-theme-dark-light](https://user-images.githubusercontent.com/29527450/229593877-9327c858-3c60-4b6d-917c-8a7cb40da574.jpg)

