### PR TITLE
Fixed issue with white space appearing at bottom of screen in dark mode when resizing browser window

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -49,8 +49,9 @@ p {
 #main {
   background-color: var(--background-color);
   padding: 6%;
-  height: 100vh;
+  min-height: 100vh;
   color: var(--text-color);
+  height:auto
 }
 /* Nav*/
 #navigation {


### PR DESCRIPTION
When dragging the bottom of the browser window up while in dark mode, a white space was appearing at the bottom of the screen. This was caused by the #main element having a fixed height of 100vh.

To fix this issue, the height value of the #main element has been changed to auto, so that it adjusts to the height of its content. A min-height value of 100vh has also been added to ensure that the element is at least the height of the viewport.

This change resolves the issue and ensures that the dark mode background color is consistent throughout the page, even when resizing the browser window.