### PR TITLE
Copy Button: Fixed button size for 'Copy to Clipboard' functionality 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -98,8 +98,6 @@ label.form-label {
   background-color: var(--secondary-color);
   border: none;
   position: absolute;
-  width: 40px;
-  height: 40px;
   bottom: 10px;
   right: 10px;
 }


### PR DESCRIPTION
Due to the fixed width and height of the button, once clicked the text "copied" would not fit on a single line.

To solve this issue, I removed the height and width properties of the button, allowing the text to fit on one line and improving the overall user experience. Users will now be able to quickly and easily copy text