### PR TITLE
Generator: Refactor to use useReducer instead of useState

### DIFF
--- a/src/components/generators/Generator.js
+++ b/src/components/generators/Generator.js
@@ -1,18 +1,37 @@
-import React, { useState } from 'react'
+import React, { useReducer } from 'react'
 import { Container, Form, Button, Card, Row, Col } from 'react-bootstrap'
-import {callAPI} from '../api/OpenAIAPI.js';
-
+import { callAPI } from '../api/OpenAIAPI.js';
 
 import CopyToClipboard from '../common/CopyToClipboard.js';
 import LoadingSpinner from '../common/LoadingSpinner.js';
 
-const GeneratorComponent = (props) => {
-  const [heading, setHeading] = useState('AI Generated Response:');
-  const [response, setResponse] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
-  const [dataLoaded, setDataLoaded] = useState(false);
-  const [isFormSubmitted, setIsFormSubmitted] = useState(false);
+const initialState = {
+  heading: 'AI Generated Response:',
+  response: '',
+  errorMessage: '',
+  dataLoaded: false,
+  isFormSubmitted: false,
+};
 
+function reducer(state, action) {
+  switch (action.type) {
+    case 'SET_HEADING':
+      return { ...state, heading: action.payload };
+    case 'SET_RESPONSE':
+      return { ...state, response: action.payload };
+    case 'SET_ERROR_MESSAGE':
+      return { ...state, errorMessage: action.payload };
+    case 'SET_DATA_LOADED':
+      return { ...state, dataLoaded: action.payload };
+    case 'SET_IS_FORM_SUBMITTED':
+      return { ...state, isFormSubmitted: action.payload };
+    default:
+      return state;
+  }
+}
+
+const GeneratorComponent = (props) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
 
   const onFormSubmit = (e) => {
     e.preventDefault();
@@ -20,23 +39,24 @@ const GeneratorComponent = (props) => {
     const formData = new FormData(e.target);
     const prompt = `${props.generatorData.prompt}${formData.get(props.generatorData.formName)}`;
 
-    setHeading(`Thinking about your ${props.generatorData.title} now...`);
-    setResponse('');
-    setErrorMessage('');
-    setIsFormSubmitted(true);
-    setDataLoaded(false);
+    dispatch({ type: 'SET_HEADING', payload: `Thinking about your ${props.generatorData.title} now...` });
+    dispatch({ type: 'SET_RESPONSE', payload: '' });
+    dispatch({ type: 'SET_ERROR_MESSAGE', payload: '' });
+    dispatch({ type: 'SET_IS_FORM_SUBMITTED', payload: true });
+    dispatch({ type: 'SET_DATA_LOADED', payload: false });
     callAPI(prompt).then((data) => {
       if (data.error) {
-        setErrorMessage(data.message);
+        dispatch({ type: 'SET_ERROR_MESSAGE', payload: data.message });
       } else {
-        setHeading(`Your AI Generated ${props.generatorData.title}:`);
-        setResponse(data);
+        dispatch({ type: 'SET_HEADING', payload: `Your AI Generated ${props.generatorData.title}:` });
+        dispatch({ type: 'SET_RESPONSE', payload: data });
       }
-      setDataLoaded(true);
+      dispatch({ type: 'SET_DATA_LOADED', payload: true });
     });
   };
 
   const { title, description2, formLabel, formName, placeholder } = props.generatorData;
+
 
   return (
     <div id="main">
@@ -59,35 +79,34 @@ const GeneratorComponent = (props) => {
           <Col xs={12} md={8}>
             <Card className="text-center">
               <Card.Header>
-                <h2>{heading}</h2>
+                <h2>{state.heading}</h2>
               </Card.Header>
               <Card.Body>
                 {
-                errorMessage ? 
-                (
-                  <p variant="danger" className="mt-3">{errorMessage}</p>
-                ) 
-                : dataLoaded && response ? 
-                (
-                  <div className="response-container">
-                    <Card.Text>
-                      <p className="pre-wrap">{response}</p>
-                    </Card.Text>
-                    {response && <CopyToClipboard text={response} />}
-                  </div>
-                ) 
-                : !isFormSubmitted ? 
-                (
-                  <Card.Text>
-                    The Response from the AI for your {title} will show here.
-                  </Card.Text>
-                ) 
-                : 
-                (
-                  <LoadingSpinner />
-                )}
+                  state.errorMessage ?
+                    (
+                      <p variant="danger" className="mt-3">{state.errorMessage}</p>
+                    )
+                    : state.dataLoaded && state.response ?
+                      (
+                        <div className="response-container">
+                          <Card.Text>
+                            <p className="pre-wrap">{state.response}</p>
+                          </Card.Text>
+                          {state.response && <CopyToClipboard text={state.response} />}
+                        </div>
+                      )
+                      : !state.isFormSubmitted ?
+                        (
+                          <Card.Text>
+                            The Response from the AI for your {title} will show here.
+                          </Card.Text>
+                        )
+                        :
+                        (
+                          <LoadingSpinner />
+                        )}
               </Card.Body>
-
             </Card>
           </Col>
         </Row>


### PR DESCRIPTION
This solves: [Refactor: GeneratorComponent to use useReducer for state management](https://github.com/ash1eygrace/ai-content/issues/48) #48 

This PR refactors the Generator component to use the `useReducer` hook for better state management. The app remains functionally the same; only the code has changed.

**The changes include:**

1. Importing `useReducer` from 'react'.
2. Defining an initial state object.
3. Defining a reducer function to manage state updates based on dispatched actions.
4. Replacing the `useState` hooks with the `useReducer` hook to get the current state and a dispatch function.
5. Updating the `onFormSubmit` function to dispatch actions instead of using the setters.
6. Updating the return statement to use the new state references from the state object.

By using `useReducer`, the app component's state is better organized and maintainable, making it easier to handle complex state updates and logic.

**Testing:** 

1. Navigate to any of the generators. Check to make sure the card title says, "AI Generated Response:" and that the card body text says: "The Response from the AI for your {generator title} will show here.
2. Type your desired prompt into the form and click submit. Ensure the Card Title changes to, "Thinking about your  {generator title} now..." and that the loading spinner shows in the card body. 
3. Finally, check to make sure the card title shows "Your AI Generated {generator title}:" and the card text shows the response from the API (or an error message if you haven't ended an API key." 
