### PR TITLE
Generator Component: Add typing effect animation to AI generated response

### DIFF
--- a/src/components/generators/Generator.js
+++ b/src/components/generators/Generator.js
@@ -4,6 +4,8 @@ import { callAPI } from '../api/OpenAIAPI.js';
 
 import CopyToClipboard from '../common/CopyToClipboard.js';
 import LoadingSpinner from '../common/LoadingSpinner.js';
+import useTypingEffect from '../../hooks/useTypingEffect.js';
+
 
 const initialState = {
   heading: 'AI Generated Response:',
@@ -33,6 +35,9 @@ function reducer(state, action) {
 const GeneratorComponent = (props) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
+  const typingSpeed = 50;
+  const responseWithTypingEffect = useTypingEffect(state.response, typingSpeed);
+
   const onFormSubmit = (e) => {
     e.preventDefault();
 
@@ -56,7 +61,6 @@ const GeneratorComponent = (props) => {
   };
 
   const { title, description2, formLabel, formName, placeholder } = props.generatorData;
-
 
   return (
     <div id="main">
@@ -91,7 +95,7 @@ const GeneratorComponent = (props) => {
                       (
                         <div className="response-container">
                           <Card.Text>
-                            <p className="pre-wrap">{state.response}</p>
+                            <p className="pre-wrap">{responseWithTypingEffect}</p>
                           </Card.Text>
                           {state.response && <CopyToClipboard text={state.response} />}
                         </div>

--- a/src/hooks/useTypingEffect.js
+++ b/src/hooks/useTypingEffect.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+const useTypingEffect = (text, typingSpeed) => {
+  const [displayText, setDisplayText] = useState('');
+
+  useEffect(() => {
+    let currentIndex = 0;
+    const interval = setInterval(() => {
+      if (currentIndex < text.length) {
+        setDisplayText((prevText) => prevText + text.charAt(currentIndex));
+        currentIndex++;
+      } else {
+        clearInterval(interval);
+      }
+    }, typingSpeed);
+
+    return () => clearInterval(interval);
+  }, [text, typingSpeed]);
+
+  return displayText;
+};
+
+export default useTypingEffect;


### PR DESCRIPTION
This solves: [Feature: Add Text Typing Animation in GeneratorComponent for OpenAI's API-Generated Text Response](https://github.com/ash1eygrace/ai-content/issues/43) #43

This pull request adds a typing effect animation to the AI-generated response in the GeneratorComponent. The text appears to be typed out, providing a more engaging user experience.

https://user-images.githubusercontent.com/29527450/229927516-414ae8b4-95a7-4fe3-9ea6-0b1525e972ce.mov


### Changes made:

1. Created a custom hook `useTypingEffect` in `src/hooks/useTypingEffect.js`, which takes the text and typing speed as arguments and returns the text with the typing effect applied.
2. Imported and implemented `useTypingEffect` in the `GeneratorComponent` (`src/components/generators/Generator.js`).
3. Declared a `responseWithTypingEffect` variable in `GeneratorComponent` to store the text with the typing effect.
4. Replaced the direct display of `state.response` with `responseWithTypingEffect` in the `return` statement of the `GeneratorComponent`.

### Testing:

1. Open any of the generators to generate content of your choosing. 
2. Once the response is received from the API you'll see it being typed out with the animation. 

Note that: 
- The typing effect animation can be observed when using a valid API key. After submitting the form, the AI-generated response will be displayed with the typing effect.
- If an API key is not provided or is invalid, the error message should be displayed without any issues.
