### PR TITLE
Generator Component: Refactor to destructure props

### DIFF
--- a/src/components/generators/Generator.js
+++ b/src/components/generators/Generator.js
@@ -32,7 +32,7 @@ function reducer(state, action) {
   }
 }
 
-const GeneratorComponent = (props) => {
+const GeneratorComponent = ({generatorData}) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const typingSpeed = 50;
@@ -42,9 +42,9 @@ const GeneratorComponent = (props) => {
     e.preventDefault();
 
     const formData = new FormData(e.target);
-    const prompt = `${props.generatorData.prompt}${formData.get(props.generatorData.formName)}`;
+    const prompt = `${generatorData.prompt}${formData.get(generatorData.formName)}`;
 
-    dispatch({ type: 'SET_HEADING', payload: `Thinking about your ${props.generatorData.title} now...` });
+    dispatch({ type: 'SET_HEADING', payload: `Thinking about your ${generatorData.title} now...` });
     dispatch({ type: 'SET_RESPONSE', payload: '' });
     dispatch({ type: 'SET_ERROR_MESSAGE', payload: '' });
     dispatch({ type: 'SET_IS_FORM_SUBMITTED', payload: true });
@@ -53,14 +53,14 @@ const GeneratorComponent = (props) => {
       if (data.error) {
         dispatch({ type: 'SET_ERROR_MESSAGE', payload: data.message });
       } else {
-        dispatch({ type: 'SET_HEADING', payload: `Your AI Generated ${props.generatorData.title}:` });
+        dispatch({ type: 'SET_HEADING', payload: `Your AI Generated ${generatorData.title}:` });
         dispatch({ type: 'SET_RESPONSE', payload: data });
       }
       dispatch({ type: 'SET_DATA_LOADED', payload: true });
     });
   };
 
-  const { title, description2, formLabel, formName, placeholder } = props.generatorData;
+  const { title, description2, formLabel, formName, placeholder } = generatorData;
 
   return (
     <div id="main">


### PR DESCRIPTION
Solves: [Refactor: Destructure Props](https://github.com/ash1eygrace/ai-content/issues/24) #24

This pull request updates the GeneratorComponent to destructure the `generatorData` prop directly in the function arguments. This makes the component code more concise and easier to read.

**Changes include:**

- Destructuring `generatorData` prop in the function arguments of `GeneratorComponent`.
- Removing the use of `props` throughout the component.
- No functional changes were made, and the component should continue to work as expected.

** To test ** 

1. Open any of the generator pages, and submit a prompt to get AI-generated content. The generator should load with the details that are passed as props (title, description, prompt example in the input field, etc. )
2. Enter a prompt to get your desired response from the AI. Functionally, the state should change to loading and then to the response with the `useTypingEffect`.  