### PR TITLE
Refactor Generator component naming and data naming conventions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Navigation from './components/common/Navigation';
 import Home from './components/pages/Home';
 import Generators from './components/generators/Generators';
-import GeneratorComponent from './components/generators/Generator';
+import Generator from './components/generators/Generator';
 
 import { generatorList } from './data/generatorList';
 import { ThemeContext } from './components/common/ThemeContext';
@@ -34,7 +34,7 @@ function App() {
               <Route
                 key={generator.id}
                 path={`/${generator.link}`}
-                element={<GeneratorComponent generatorData={generator} />}
+                element={<Generator generatorData={generator} />}
               />
             ))}
           </Routes>

--- a/src/components/generators/Generator.js
+++ b/src/components/generators/Generator.js
@@ -32,7 +32,7 @@ function reducer(state, action) {
   }
 }
 
-const GeneratorComponent = ({generatorData}) => {
+const Generator = ({generatorData}) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const typingSpeed = 50;
@@ -119,4 +119,4 @@ const GeneratorComponent = ({generatorData}) => {
   );
 };
 
-export default GeneratorComponent;
+export default Generator;


### PR DESCRIPTION
This pull request includes a refactor to improve the naming conventions for the Generator component and the generatorList.js file:

1. Renamed `GeneratorComponent` to `Generator` to simplify the component name, as the 'Component' suffix is redundant for React components.
2. Changed the filename `GeneratorList.js` to `generatorList.js` to better reflect that it contains data rather than a component, following typical naming conventions for non-component files.

No functionality of the app has changed. It compiles and functions as expected. 