### PR TITLE
Add API options to generator data and pass them through Generator to callAPI function

### DIFF
--- a/src/components/api/OpenAIAPI.js
+++ b/src/components/api/OpenAIAPI.js
@@ -1,6 +1,6 @@
 const { Configuration, OpenAIApi } = require('openai')
 
-export async function callAPI(prompt) {
+export async function callAPI(prompt, options) {
     // OpenAI davinci completion
     const configuration = new Configuration({
         apiKey: process.env.REACT_APP_API_KEY,
@@ -10,20 +10,20 @@ export async function callAPI(prompt) {
 
     const openAPICall = openai.createCompletion("text-davinci-002", {
         prompt: prompt,
-        temperature: 0.6,
-        max_tokens: 150,
-        top_p: 1,
-        frequency_penalty: 1,
-        presence_penalty: 1,
+        temperature: options.temperature,
+        max_tokens: options.max_tokens,
+        top_p: options.top_p,
+        frequency_penalty: options.frequency_penalty,
+        presence_penalty: options.presence_penalty,
     })
-    .then(response => {
-        return `${response.data.choices[0].text}`
-    })
-    .catch(error => {
-        console.log(error);
-        return { error: true, message: "Sorry, there was an error with your request. Please make sure your API Key is valid and try again later. If the issue persists, please try again later." };
-    })
-    
+        .then(response => {
+            return `${response.data.choices[0].text}`
+        })
+        .catch(error => {
+            console.log(error);
+            return { error: true, message: "Sorry, there was an error with your request. Please make sure your API Key is valid and try again later. If the issue persists, please try again later." };
+        })
+
     return await openAPICall;
 
 }

--- a/src/components/generators/Generator.js
+++ b/src/components/generators/Generator.js
@@ -32,7 +32,7 @@ function reducer(state, action) {
   }
 }
 
-const Generator = ({generatorData}) => {
+const Generator = ({ generatorData }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const typingSpeed = 50;
@@ -49,7 +49,13 @@ const Generator = ({generatorData}) => {
     dispatch({ type: 'SET_ERROR_MESSAGE', payload: '' });
     dispatch({ type: 'SET_IS_FORM_SUBMITTED', payload: true });
     dispatch({ type: 'SET_DATA_LOADED', payload: false });
-    callAPI(prompt).then((data) => {
+    callAPI(prompt, {
+      temperature: generatorData.temperature,
+      max_tokens: generatorData.max_tokens,
+      top_p: generatorData.top_p,
+      frequency_penalty: generatorData.frequency_penalty,
+      presence_penalty: generatorData.presence_penalty,
+    }).then((data) => {
       if (data.error) {
         dispatch({ type: 'SET_ERROR_MESSAGE', payload: data.message });
       } else {

--- a/src/data/generatorList.js
+++ b/src/data/generatorList.js
@@ -9,7 +9,12 @@ export const generatorList = [
         description2: 'Enter your your content topic to generate a list of blog post ideas.',
         formLabel: 'Topic:',
         formName: 'topic',
-        placeholder: 'e.g. Finance'
+        placeholder: 'e.g. Finance',
+        temperature: 0.6,
+        max_tokens: 150,
+        top_p: 1,
+        frequency_penalty: 1,
+        presence_penalty: 1,
     },
     {
         id: 2,
@@ -21,7 +26,12 @@ export const generatorList = [
         description2: 'Enter your your product and a few keywords to include in your output. Click Submit and get a product description generated for you by AI. Think less and sell more.',
         formLabel: 'Product Name & Purpose:',
         formName: 'productName',
-        placeholder: 'e.g. ScoobySnacks will make your dog chill out'
+        placeholder: 'e.g. ScoobySnacks will make your dog chill out',
+        temperature: 0.6,
+        max_tokens: 150,
+        top_p: 1,
+        frequency_penalty: 1,
+        presence_penalty: 1,
     },
     {
         id: 3,
@@ -33,7 +43,12 @@ export const generatorList = [
         description2: 'Enter your company name and a few keywords that you\'d like to include in your output. Click Submit and get a company bio generated for you by AI. Think less and sell more.',
         formLabel: 'Company Name & Purpose:',
         formName: 'companyName',
-        placeholder: 'e.g. Dunder Mifflin the best paper company '
+        placeholder: 'e.g. Dunder Mifflin the best paper company ',
+        temperature: 0.6,
+        max_tokens: 150,
+        top_p: 1,
+        frequency_penalty: 1,
+        presence_penalty: 1,
     },
     {
         id: 4,
@@ -45,7 +60,12 @@ export const generatorList = [
         description2: 'Enter your blog posts title and SEO keywords that you\'d like to include in your output. Click Submit and get a blog post introduction paragraph generated for you by AI. Think less and publish more.',
         formLabel: 'Blog post title:',
         formName: 'blogTitle',
-        placeholder: 'e.g. How to Make a Commit with Git'
+        placeholder: 'e.g. How to Make a Commit with Git',
+        temperature: 0.6,
+        max_tokens: 150,
+        top_p: 1,
+        frequency_penalty: 1,
+        presence_penalty: 1,
     },
     {
         id: 5,
@@ -57,7 +77,12 @@ export const generatorList = [
         description2: 'Enter your your job title, click submit, and get a job description generated for you by AI.',
         formLabel: 'Job Title:',
         formName: 'jobTitle',
-        placeholder: 'e.g. Software Engineer specializing in AI'
+        placeholder: 'e.g. Software Engineer specializing in AI',
+        temperature: 0.6,
+        max_tokens: 150,
+        top_p: 1,
+        frequency_penalty: 1,
+        presence_penalty: 1,
     },
     {
         id: 6,
@@ -69,6 +94,11 @@ export const generatorList = [
         description2: 'Enter your your verbose text, click submit, and get a TL;DR generated for you by AI.',
         formLabel: 'Paragraph:',
         formName: 'longParagraph',
-        placeholder: 'paste your text here'
+        placeholder: 'paste your text here',
+        temperature: 0.6,
+        max_tokens: 150,
+        top_p: 1,
+        frequency_penalty: 1,
+        presence_penalty: 1,
     }
 ];


### PR DESCRIPTION
The first step to completing [Add sliders to customize OpenAI ](https://github.com/ash1eygrace/ai-content/issues/5)results #5

This pull request adds API options to each generator in the `generatorList` data and updates the `callAPI` function to accept these options as an argument. The `Generator` component has also been updated to pass the options from the generator data to the `callAPI` function. This allows each generator to have its own set of API options which can be easily customized.

For now, I've not fine-tuned the data, and all the options remain the same; they've just been moved out of the API function and into the data.

**Changes:**

1. Update `generatorList` data to include API options for each generator
2. Modify the `callAPI` function to accept the API options as an argument
3. Update the Generator component to pass the API options to the `callAPI` function

**Testing Instructions:**

1. Navigate to the different generator pages and submit the form for each generator.
2. Verify that the AI-generated responses are still being displayed and that you receive a response from the API