### PR TITLE
Generator: Refactor onFormSubmit to use async/await

### DIFF
--- a/src/components/generators/Generator.js
+++ b/src/components/generators/Generator.js
@@ -38,7 +38,7 @@ const Generator = ({ generatorData }) => {
   const typingSpeed = 50;
   const responseWithTypingEffect = useTypingEffect(state.response, typingSpeed);
 
-  const onFormSubmit = (e) => {
+  const onFormSubmit = async (e) => {
     e.preventDefault();
 
     const formData = new FormData(e.target);
@@ -49,22 +49,29 @@ const Generator = ({ generatorData }) => {
     dispatch({ type: 'SET_ERROR_MESSAGE', payload: '' });
     dispatch({ type: 'SET_IS_FORM_SUBMITTED', payload: true });
     dispatch({ type: 'SET_DATA_LOADED', payload: false });
-    callAPI(prompt, {
-      temperature: generatorData.temperature,
-      max_tokens: generatorData.max_tokens,
-      top_p: generatorData.top_p,
-      frequency_penalty: generatorData.frequency_penalty,
-      presence_penalty: generatorData.presence_penalty,
-    }).then((data) => {
+
+    try {
+      const data = await callAPI(prompt, {
+        temperature: generatorData.temperature,
+        max_tokens: generatorData.max_tokens,
+        top_p: generatorData.top_p,
+        frequency_penalty: generatorData.frequency_penalty,
+        presence_penalty: generatorData.presence_penalty,
+      });
+
       if (data.error) {
         dispatch({ type: 'SET_ERROR_MESSAGE', payload: data.message });
       } else {
         dispatch({ type: 'SET_HEADING', payload: `Your AI Generated ${generatorData.title}:` });
         dispatch({ type: 'SET_RESPONSE', payload: data });
       }
+    } catch (error) {
+      console.error("Error:", error);
+    } finally {
       dispatch({ type: 'SET_DATA_LOADED', payload: true });
-    });
+    }
   };
+
 
   const { title, description2, formLabel, formName, placeholder } = generatorData;
 


### PR DESCRIPTION
This pull request refactors the `onFormSubmit` function in the Generator component to use the async/await pattern with try/catch instead of the previous `.then()` approach.

### Changes
- Updated the `onFormSubmit` function in the Generator component to be an `async` function.
- Replaced the `.then()` call with `await callAPI(...)`.
- Wrapped the API call within a try block to handle success.
- Implemented a catch block to handle errors.
- Added a finally block to ensure that the data loaded state is updated regardless of success or error.

### Benefits
- Improves code readability and makes it easier to understand the flow of execution.
- Simplifies error handling with a single try/catch block.
- Ensures consistency with modern JavaScript best practices.

### Testing:

Try with and without an API key to make sure the response is displayed, or an error if there's no API Key