### PR TITLE
Fix: Clear previous response before displaying new response with typing effect

### DIFF
--- a/src/hooks/useTypingEffect.js
+++ b/src/hooks/useTypingEffect.js
@@ -4,6 +4,7 @@ const useTypingEffect = (text, typingSpeed) => {
   const [displayText, setDisplayText] = useState('');
 
   useEffect(() => {
+    setDisplayText('');
     let currentIndex = 0;
     const interval = setInterval(() => {
       if (currentIndex < text.length) {


### PR DESCRIPTION
This PR addresses an issue that was introduced with the `useTypingEffect` hook in #43 , where the new response was appended to the previous response instead of replacing it. The changes in this PR ensure that the previous response is cleared before displaying the new response is added with the typing effect.

**Changes:**
- Updated the `useTypingEffect` hook to clear the `displayText` state before starting a new typing effect by adding `setDisplayText('');`