### PR TITLE
Fix: Resolve warning for nested <p> tags in Card.Text component

### DIFF
--- a/src/components/generators/Generator.js
+++ b/src/components/generators/Generator.js
@@ -107,8 +107,8 @@ const Generator = ({ generatorData }) => {
                     : state.dataLoaded && state.response ?
                       (
                         <div className="response-container">
-                          <Card.Text>
-                            <p className="pre-wrap">{responseWithTypingEffect}</p>
+                          <Card.Text as="div" className="pre-wrap">
+                            {responseWithTypingEffect}
                           </Card.Text>
                           {state.response && <CopyToClipboard text={state.response} />}
                         </div>


### PR DESCRIPTION
This PR resolves the console warning related to nested <p> tags inside the Card.Text component.

**Changes:**

- Replaced the nested <p> tag with the Card.Text component's `as` attribute and applied the "pre-wrap" class directly to the `Card.Text` component.

By making these changes, the app no longer displays the warning `validateDOMNesting(...): <p> cannot appear as a descendant of <p>.` in the console.
